### PR TITLE
Build processor struct to bring in values from Managers to DataAnalysis

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -66,6 +66,8 @@
       { "elastic_range": [6171, 6183], "prod_range": [6184, 7500],
         "path": "reference_waveforms/RWF_6171_6183_Setting.txt" }
     ],
+    "timemean": 50.0,
+    "timemean2": 150.0,
     "channels": [
       { "name": "blocks", "range": [0,1079]},
       { "name": "scintillators", "range": [2000,2001] } 

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -5,3 +5,4 @@
 // Define the number of samples in a waveform block.
 constexpr size_t NumSamples = 110;
 constexpr size_t DataBlockSize = 112;
+constexpr double adcSampleDivisions = 16.0;

--- a/include/DataAnalysisManager.hpp
+++ b/include/DataAnalysisManager.hpp
@@ -14,6 +14,7 @@ class GlobalManager;
 class ReferenceManager;
 class BranchManager;
 class FileManager;
+class ApplicationManager;
 
 struct ProcessingConfig {
     int nCores = -1;
@@ -28,17 +29,16 @@ struct ProcessingConfig {
 class DataAnalysisManager {
 public:
     // The constructor now takes pointers (or const references) to the other managers.
-    DataAnalysisManager(int run,
-                        TChain* chain,
-                        const FileManager* fileMgr,
+    DataAnalysisManager(const FileManager* fileMgr,
                         const GlobalManager* globalMgr,
                         const ReferenceManager* refMgr,
-                        const BranchManager* branchMgr);
+                        const BranchManager* branchMgr,
+                        const ApplicationManager* applicationMgr);
     void ProcessData();
 
 private:
 
-    void SetupParameters() const;
+    void SetupParameters();
     
     TChain* chain;
     int run;

--- a/include/DataAnalysisManager.hpp
+++ b/include/DataAnalysisManager.hpp
@@ -15,6 +15,16 @@ class ReferenceManager;
 class BranchManager;
 class FileManager;
 
+struct ProcessingConfig {
+    int nCores = -1;
+    double peakTolerance = 0.;
+    float timemean = 0.0f;
+    float timemean2 = 0.0f;
+    float timerefacc = 0.0f;
+    std::map<int,double> tdcOffsets;
+    std::map<int,double> timeRefs;
+};
+
 class DataAnalysisManager {
 public:
     // The constructor now takes pointers (or const references) to the other managers.
@@ -27,15 +37,18 @@ public:
     void ProcessData();
 
 private:
-    TChain* chain;
-    FileIOConfig fileConfig;
-    int run;
 
+    void SetupParameters() const;
+    
+    TChain* chain;
+    int run;
+    ProcessingConfig cfg;
     // Pointers to the other managers.
     const GlobalManager* globalManager;
     const ReferenceManager* referenceManager;
     const BranchManager* branchManager;
     const FileManager* fileManager;
+    const ApplicationManager* applicationManager;
 };
 
 #endif // DATA_ANALYSIS_MANAGER_HPP

--- a/include/DataTypes.hpp
+++ b/include/DataTypes.hpp
@@ -44,13 +44,14 @@ struct AdcEventData {
 
 // A single peak, storing amplitude and time
 struct Peak {
+    int block = 0;
     float amplitude = 0;
     float time = 0;
 };
 
 // Container to store up to 12 peaks per waveform block.
 struct PeakContainer {
-    static constexpr int maxPeaks = 12;
+    static constexpr int maxPeaks = 12; // Should be set by global configuration
     int nPeaks = 0;                      // Actual number of peaks found
     int peakOverflow = 0;
     std::array<Peak, maxPeaks> peaks{};  // Storage for peaks

--- a/include/DataTypes.hpp
+++ b/include/DataTypes.hpp
@@ -44,7 +44,6 @@ struct AdcEventData {
 
 // A single peak, storing amplitude and time
 struct Peak {
-    int block = 0;
     float amplitude = 0;
     float time = 0;
 };
@@ -52,6 +51,7 @@ struct Peak {
 // Container to store up to 12 peaks per waveform block.
 struct PeakContainer {
     static constexpr int maxPeaks = 12; // Should be set by global configuration
+    int block = 0;
     int nPeaks = 0;                      // Actual number of peaks found
     int peakOverflow = 0;
     std::array<Peak, maxPeaks> peaks{};  // Storage for peaks

--- a/include/GlobalManager.hpp
+++ b/include/GlobalManager.hpp
@@ -13,6 +13,7 @@ public:
     int GetNtime() const;
     int GetNchannel() const;
     int GetNcol() const;
+    double GetTimeRefAcc() const;
     double GetPeakTolerance() const;
     void ApplyConfig(int run); 
     // You can add additional getters as needed.

--- a/include/ManagerConfigs.hpp
+++ b/include/ManagerConfigs.hpp
@@ -95,6 +95,8 @@ struct ChannelType {
 // specific to the reference manager.
 struct ReferenceConfig {
     // Waveform file patterns and default.
+    float timemean;
+    float timemean2;
     std::vector<FilePattern> waveformPatterns;
     std::vector<ChannelType> ChannelTypes;
     std::string waveformDefault;

--- a/include/ReferenceManager.hpp
+++ b/include/ReferenceManager.hpp
@@ -18,6 +18,11 @@ public:
 
     const ROOT::Math::Interpolator* GetInterpolator(int block) const;
     TF1* GetFitter(int block) const;
+    
+    std::map<int,double> GetTimeRefs() const;
+    std::map<int,double> GettdcOffsets() const;
+    double GetTimeMean() const;
+    double GetTimeMean2() const;
     void ApplyConfig(int _run);
 private:
     RunType runType;
@@ -26,6 +31,9 @@ private:
     bool LoadReferenceWaveforms();
     // Maps to store interpolators and fitters.
     std::map<int, std::unique_ptr<ROOT::Math::Interpolator>> interpolators;
+    // TODO: Get 
+    std::map<int,double> timeRefs;
+    std::map<int,double> tdcOffsets;
     std::map<int, std::unique_ptr<TF1>> fitters;
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 #include "TSystem.h"
 #include "ConfigManager.hpp"
 #include "FileManager.hpp"
+#include "ApplicationManager.hpp"
 #include "BranchManager.hpp"
 #include "GlobalManager.hpp"
 #include "ReferenceManager.hpp"
@@ -52,6 +53,8 @@ int main(int argc, char* argv[]) {
         std::cout << "Utilizing " << applicationCfg.nProcessors << " processors\n";
 
         // Create and use managers.
+        ApplicationManager applicationManager(applicationCfg);
+        applicationManager.ApplyConfig(run);
         FileManager fileManager(fileCfg);
         fileManager.ApplyConfig(run);
         TChain* chain = fileManager.GetInputChain();
@@ -60,11 +63,11 @@ int main(int argc, char* argv[]) {
         ReferenceManager refManager(refCfg);
 
         // Pass references of managers to analysisManager
-        DataAnalysisManager analysisManager(run, chain,
-                                            &fileManager,
+        DataAnalysisManager analysisManager(&fileManager,
                                             &globalManager,
                                             &refManager,
-                                            &branchManager
+                                            &branchManager,
+                                            &applicationManager
         );
 
         // Example output.

--- a/main.cpp
+++ b/main.cpp
@@ -55,12 +55,19 @@ int main(int argc, char* argv[]) {
         // Create and use managers.
         ApplicationManager applicationManager(applicationCfg);
         applicationManager.ApplyConfig(run);
+
         FileManager fileManager(fileCfg);
         fileManager.ApplyConfig(run);
         TChain* chain = fileManager.GetInputChain();
+
         BranchManager branchManager(chain, branchCfg);
+        branchManager.ApplyConfig(run);
+
         GlobalManager globalManager(globalCfg);
+        globalManager.ApplyConfig(run);
+
         ReferenceManager refManager(refCfg);
+        refManager.ApplyConfig(run);
 
         // Pass references of managers to analysisManager
         DataAnalysisManager analysisManager(&fileManager,

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -126,6 +126,9 @@ void ConfigManager::LoadReferenceConfig() {
         std::vector<std::pair<int, int>> allProdRanges;
         std::vector<std::pair<int, int>> allElasticRanges;
 
+        referenceConfig.timemean = wfFiles.at("timemean").get<float>();
+        referenceConfig.timemean2 = wfFiles.at("timemean2").get<float>();
+
         for (const auto& pat : wfFiles.at("patterns")) {
             FilePattern fp;
             fp.rangeStart   = pat.at("prod_range")[0].get<int>();

--- a/src/DataAnalysisManager.cpp
+++ b/src/DataAnalysisManager.cpp
@@ -88,11 +88,14 @@ void DataAnalysisManager::ProcessData() {
             blocks.reserve(nBlocks);
             for (int i = 0; i < nBlocks; ++i) {
                 size_t offset = i * _DataBlockSize;
-                float block_id = flat_data[offset];
+                float channel = flat_data[offset];
+                // Only Save Waveforms from the block channels.
+                // Should add a more robust method here like isBlock(channel).
+                if(channel == 2000 || channel == 2001) {continue;}
                 float n_samples = flat_data[offset + 1];
                 size_t num_to_copy = std::min<size_t>(n_samples, NumSamples);
                 const float* waveform_ptr = &flat_data[offset + 2];
-                blocks.emplace_back(block_id, n_samples, waveform_ptr, num_to_copy);
+                blocks.emplace_back(channel, n_samples, waveform_ptr, num_to_copy);
             }
             return blocks;
         },
@@ -167,21 +170,10 @@ void DataAnalysisManager::ProcessData() {
             int Npulse = 0;
             AdcEventData eventData;
             eventData.adcResults.resize(NadcCounters);
-
-            // Skip if adcCounter is for Scintillators
-            int counter = adcCounters[0];
-            auto it = _tdcoffset.find(counter);
-            double offset = 0.0;
-            
-            if (it != _tdcoffset.end()) {
-                offset = it->second;
-            } else {
-                std::cerr << "Warning: Missing tdcOffset for adcCounter " << counter << " — using 0.0\n";
-            }
             
             eventData.HMS_corr_time = adcSampPulseTime[0] -
                                       (adcSampPulseTimeRaw[0] / _adcSampleDivisions) -
-                                      offset;
+                                      _tdcoffset.at(adcCounters[0]);
             
                                       // The _tdcoffset for adcCounters[0],
                                       // IDK what that is.
@@ -212,13 +204,7 @@ void DataAnalysisManager::ProcessData() {
     auto isGoodPeak = [_timeref = cfg.timeRefs, 
                        _peakTolerance = cfg.peakTolerance,
                        _timerefacc = cfg.timerefacc](int block_number, double peakTime) -> bool {
-        auto it = _timeref.find(block_number);
-        if (it != _timeref.end()) {
-            return std::fabs(peakTime - it->second - _timerefacc) < _peakTolerance;
-        } else {
-            std::cerr << "Warning: Missing timeref for block " << block_number << " — using 0.0\n";
-            return std::fabs(peakTime - 0.0 - _timerefacc) < _peakTolerance;  // fallback
-        }
+        return std::fabs(peakTime - _timeref.at(block_number) - _timerefacc) < _peakTolerance;
     };
 
     // Lambda to compute fit parameters for each block.

--- a/src/DataAnalysisManager.cpp
+++ b/src/DataAnalysisManager.cpp
@@ -1,5 +1,6 @@
 #include "DataAnalysisManager.hpp"
 #include "GlobalManager.hpp"
+#include "ApplicationManager.hpp"
 #include "ReferenceManager.hpp"
 #include "BranchManager.hpp"
 #include "FileManager.hpp"
@@ -15,34 +16,41 @@ DataAnalysisManager::DataAnalysisManager(int run,
                                          const FileManager* fileMgr,
                                          const GlobalManager* globalMgr,
                                          const ReferenceManager* refMgr,
-                                         const BranchManager* branchMgr)
+                                         const BranchManager* branchMgr,
+                                         const ApplicationManager* appMgr)
     : run(run), chain(chain), fileManager(fileMgr),
-      globalManager(globalMgr), referenceManager(refMgr), branchManager(branchMgr)
+      globalManager(globalMgr), referenceManager(refMgr), branchManager(branchMgr,
+      applicationManager(applicationMgr) )
 {
 }
 
-void DataAnalysisManager::ProcessData() {
-    // Retrieve configuration from GlobalManager (or ProcessingSettingsManager, when implemented)
-    // For example, the number of cores and analysis version.
-    int nCores = 15;  // Default
-    double peakTolerance = 4.1;  // Default timing tolerance
-    
-    if (globalManager) {
-        //nCores = globalManager->GetNumCores();
-        peakTolerance = globalManager->GetPeakTolerance();
+void DataAnalysisManager::SetupParameters() const {
+    if(applicationManager) {
+        cfg.nCores = applicationManager->GetNProcs();
     }
-    // (Optionally, verify that the waveform_analysis_version is supported.)
+    if (globalManager) {
+        cfg.peakTolerance = globalManager->GetPeakTolerance();
+        cfg.timerefacc = globalManager->GetTimeRefAcc();
+    }
+    if (referenceManager) {
+        cfg.timeRefs = referenceManager->GetTimeRefs();
+        cfg.tdcOffsets = referenceManager->GettdcOffsets();
+        cfg.timemean = referenceManager->GetTimeMean();
+        cfg.timemean2 = referenceManager->GetTimeMean2();
+    }
+}
+
+void DataAnalysisManager::ProcessData() {
+    // Check WaveformAnalysis Version
 
     // Enable multi-threading using the number of cores from configuration.
     ROOT::EnableImplicitMT(nCores);
 
     // Create the initial RDataFrame from the TChain.
-    // if(fileManager) {
-    //     chain = fileManager->LoadTChain(run);
-    // }    
     ROOT::RDataFrame df(*chain);
 
     // Step 1: Filter events based on tracking cuts.
+    //TODO: Specify cut values in configuration
     auto dfFiltered = df.Filter(
         [](double th, double ph, double dp) {
             return std::fabs(th) < 0.08 && std::fabs(ph) < 0.04 && std::fabs(dp) < 10;
@@ -66,8 +74,8 @@ void DataAnalysisManager::ProcessData() {
     // Step 3a: Determine Number of Waveforms assuming DataBlockSized DataBlocks
     // Save the size for use in future steps.
     auto dfSizeBlocks = dfWaveform.Define("n_blocks",
-        [] (int adcSampWaveformSize) {
-            return adcSampWaveformSize / static_cast<int>(DataBlockSize);
+        [_DataBlockSize = DataBlockSize] (int adcSampWaveformSize) {
+            return adcSampWaveformSize / static_cast<int>(_DataBlockSize);
         },
         {"Ndata.NPS.cal.fly.adcSampWaveform"}
     );
@@ -75,11 +83,11 @@ void DataAnalysisManager::ProcessData() {
     // Step 3b: Make DataBlockFloat structures from raw float arrays.
     // Future steps can operate directly on DataBlockFloats within each event.
     auto dfFlattened = dfSizeBlocks.Define("blocks_float",
-        [](const std::vector<float>& flat_data, int nBlocks) -> std::vector<DataBlockFloat> {
+        [_DataBlockSize = DataBlockSize](const std::vector<float>& flat_data, int nBlocks) -> std::vector<DataBlockFloat> {
             std::vector<DataBlockFloat> blocks;
             blocks.reserve(nBlocks);
             for (int i = 0; i < nBlocks; ++i) {
-                size_t offset = i * DataBlockSize;
+                size_t offset = i * _DataBlockSize;
                 float block_id = flat_data[offset];
                 float n_samples = flat_data[offset + 1];
                 size_t num_to_copy = std::min<size_t>(n_samples, NumSamples);
@@ -91,15 +99,16 @@ void DataAnalysisManager::ProcessData() {
         {"waveform_block_data_float", "n_blocks"}
     );
 
-    auto findPeaks = [](const DataBlockFloat &block) -> PeakContainer {
+    auto findPeaks = [_NumSamples = NumSamples](const DataBlockFloat &block) -> PeakContainer {
         PeakContainer result;
-        for (int it = 0; it < NumSamples - 6; ++it) {
+        for (int it = 0; it < _NumSamples - 6; ++it) {
             if (block.data[it] < block.data[it+1] &&
                 block.data[it+1] < block.data[it+2] &&
                 block.data[it+2] <= block.data[it+3] &&
                 block.data[it+3] >= block.data[it+4] &&
                 block.data[it+4] > 0) {
                 if (result.nPeaks < PeakContainer::maxPeaks) {
+                    result.peaks[result.nPeaks].block = block.block_id;
                     result.peaks[result.nPeaks].amplitude = block.data[it+3];
                     result.peaks[result.nPeaks].time = static_cast<float>(it+3);
                     result.nPeaks++;
@@ -116,11 +125,11 @@ void DataAnalysisManager::ProcessData() {
     // Step 4: Find Peaks within each DataBlockFloat.Data()
     // Find all the peak amplitude and time within the individual DataBlockFloat objects.
     auto dfPeaks = dfFlattened.Define("block_peaks",
-        [findPeaks](const std::vector<DataBlockFloat>& blocks) -> std::vector<PeakContainer> {
+        [_findPeaks = findPeaks](const std::vector<DataBlockFloat>& blocks) -> std::vector<PeakContainer> {
             std::vector<PeakContainer> peaks;
             peaks.reserve(blocks.size());
             for (const auto &block : blocks) {
-                peaks.push_back(findPeaks(block));
+                peaks.push_back(_findPeaks(block));
             }
             return peaks;
         },
@@ -128,12 +137,12 @@ void DataAnalysisManager::ProcessData() {
     );
 
     // Lambda to process a single ADC entry.
-    auto processAdcEntry = [](AdcResult& res,
+    auto processAdcEntry = [_timemean2 = timemean2](AdcResult& res,
         float pulseAmp, float pulseTime, float pulseInt,
-        float pulsePed, float timemean2, int Npulse) {
+        float pulsePed, int Npulse) {
         // If it's the first pulse or the new pulse is closer to the reference time, update the result.
-        if (Npulse == 1 || std::fabs(res.Samptime - timemean2) > 
-                               std::fabs(pulseTime    - timemean2)) {
+        if (Npulse == 1 || std::fabs(res.Samptime - _timemean2) > 
+                           std::fabs(pulseTime    - _timemean2)) {
             res.Sampampl = pulseAmp;
             res.Samptime = pulseTime;
             res.Sampener = pulseInt;
@@ -141,17 +150,13 @@ void DataAnalysisManager::ProcessData() {
         }
     };
 
-    // if (globalManager) {
-    //     timemean2 = globalManager->GetTimeMean();
-    //     adcSampleDivisions = globalManager->GetAdcDivisions();
-    // }
     // Step 5: Calculate ADC parameters.
     // Here we encapsulate the ADC logic (like computing HMS time corrections,
-    // if(ReferenceManager) {
-    //     // tdcoffset = ReferenceManager->GetTdcOffset(blk?);
-    // }
     auto dfAdc = dfPeaks.Define("adc_results",
-        [processAdcEntry](int NadcCounters,
+        [_processAdcEntry = processAdcEntry,
+         _tdcoffset = tdcoffset,
+         _adcSampleDivisions = adcSampleDivisions,
+         timemean2 = timemean2,](int NadcCounters,
                            const ROOT::RVec<double>& adcCounters,
                            const ROOT::RVec<double>& adcSampPulseTime,
                            const ROOT::RVec<double>& adcSampPulseTimeRaw,
@@ -159,24 +164,26 @@ void DataAnalysisManager::ProcessData() {
                            const ROOT::RVec<double>& adcSampPulseInt,
                            const ROOT::RVec<double>& adcSampPulsePed) -> AdcEventData {
             // Pull values from GlobalManager (or set defaults)
-            float tdcoffset = 0.0;
-            float timemean2 = 150.0;
-            float adcSampleDivisions = 16.0;
             int Npulse = 0;
             AdcEventData eventData;
             eventData.adcResults.resize(NadcCounters);
+
+            // Skip if adcCounter is for Scintillators
     
             eventData.HMS_corr_time = adcSampPulseTime[0] -
-                                      (adcSampPulseTimeRaw[0] / adcSampleDivisions) -
-                                      tdcoffset;
+                                      (adcSampPulseTimeRaw[0] / _adcSampleDivisions) -
+                                      _tdcoffset[adcCounters[0]];
+                                      // The _tdcoffset for adcCounters[0],
+                                      // IDK what that is.
+                                      // Maybe the block that fired off the event?
     
             for (int i = 0; i < NadcCounters; ++i) {
-                processAdcEntry(eventData.adcResults[i],
+                _processAdcEntry(eventData.adcResults[i],
                                 static_cast<float>(adcSampPulseAmp[i]),
                                 static_cast<float>(adcSampPulseTime[i]),
                                 static_cast<float>(adcSampPulseInt[i]),
                                 static_cast<float>(adcSampPulsePed[i]),
-                                timemean2, Npulse);
+                                Npulse);
                 Npulse++;
             }
             eventData.Npulse = Npulse;
@@ -192,31 +199,27 @@ void DataAnalysisManager::ProcessData() {
     );
 
     // Lambda for checking peak quality using the tolerance from GlobalManager.
-    auto isGoodPeak = [peakTolerance](double peakTime, double timeref, double timerefacc) -> bool {
-        return std::fabs(peakTime - timeref - timerefacc) < peakTolerance;
+    auto isGoodPeak = [_timeref = timeref, 
+                       _peakTolerance = peakTolerance,
+                       _timerefacc = timerefacc](int block_number, double peakTime) -> bool {
+        return std::fabs(peakTime - _timeref[block_number] - _timerefacc) < _peakTolerance;
     };
 
-    double timeref, timerefacc;
-    if(referenceManager) {
-        timeref = 100.0;   // placeholder; ideally obtained from ReferenceManager
-    }
-    if(globalManager) {
-        timerefacc = 50.0; // placeholder; ideally obtained from GlobalManager
-    }
     // Lambda to compute fit parameters for each block.
-    auto computeFitParameters = [timeref, timerefacc, isGoodPeak](const std::vector<PeakContainer>& blockPeaks) -> std::vector<FitResults> {
+    auto computeFitParameters = [_isGoodPeak = isGoodPeak,
+                                 timerefacc = timerefacc]
+            (const std::vector<PeakContainer>& blockPeaks) -> std::vector<FitResults> {
         std::vector<FitResults> results;
         results.reserve(blockPeaks.size());
-
 
         for (const auto &pc : blockPeaks) {
             FitResults res;
             res.good = false;
-            res.time = timerefacc;      // fallback time
+            res.time = 0.;      // fallback time
             res.amplitude = 2.0;         // fallback amplitude
 
             for (int i = 0; i < pc.nPeaks; ++i) {
-                if (isGoodPeak(pc.peaks[i].time, timeref, timerefacc)) {
+                if (_isGoodPeak(pc.peaks[i].block, pc.peaks[i].time)) {
                     res.good = true;
                     res.time = pc.peaks[i].time;
                     res.amplitude = pc.peaks[i].amplitude;
@@ -252,11 +255,7 @@ void DataAnalysisManager::ProcessData() {
     // Should likely flatten objects and store minimal arrays instead of vectors.  
     // Can follow the Ndata pattern like hcana (input).
 
-    //TODO: Use outfile pattern instead of flattened_output.root
-    std::string outputPath = fileConfig.basePath + fileConfig.outputSubdir + "flattened_output.root";
-    std::cout << "Writing flattened output to: " << outputPath << std::endl;
-
     // Write the final TTree to disk. Note: Snapshot is the terminal action.
     //if(fileManager)
-    dfFitParams.Snapshot(fileConfig.outputTree, outputPath, outputBranches);
+    dfFitParams.Snapshot("TOUT", "output/tmp.root", outputBranches);
 }

--- a/src/DataAnalysisManager.cpp
+++ b/src/DataAnalysisManager.cpp
@@ -59,21 +59,21 @@ void DataAnalysisManager::ProcessData() {
     );
 
     // Step 2: Convert the raw waveform data from double to float.
-    // We define a new branch "waveform_block_data_float" that converts the raw data.
-    auto dfWaveform = dfFiltered.Define("waveform_block_data_float",
+    // We define a new branch "float_waveform_data" that converts the raw data.
+    auto dfWaveform = dfFiltered.Define("float_waveform_data",
         [](const ROOT::RVec<double>& waveform, int nsamp) -> std::vector<float> {
-            std::vector<float> flat_data;
-            flat_data.reserve(nsamp);
-            std::transform(waveform.begin(), waveform.end(), std::back_inserter(flat_data),
+            std::vector<float> float_data;
+            float_data.reserve(nsamp);
+            std::transform(waveform.begin(), waveform.end(), std::back_inserter(float_data),
                            [](double x) { return static_cast<float>(x); });
-            return flat_data;
+            return float_data;
         },
         {"NPS.cal.fly.adcSampWaveform", "Ndata.NPS.cal.fly.adcSampWaveform"}
     );
 
     // Step 3a: Determine Number of Waveforms assuming DataBlockSized DataBlocks
     // Save the size for use in future steps.
-    auto dfSizeBlocks = dfWaveform.Define("n_blocks",
+    auto dfSizeBlocks = dfWaveform.Define("n_channels",
         [_DataBlockSize = DataBlockSize] (int adcSampWaveformSize) {
             return adcSampWaveformSize / static_cast<int>(_DataBlockSize);
         },
@@ -82,28 +82,29 @@ void DataAnalysisManager::ProcessData() {
 
     // Step 3b: Make DataBlockFloat structures from raw float arrays.
     // Future steps can operate directly on DataBlockFloats within each event.
-    auto dfFlattened = dfSizeBlocks.Define("blocks_float",
-        [_DataBlockSize = DataBlockSize](const std::vector<float>& flat_data, int nBlocks) -> std::vector<DataBlockFloat> {
+    auto dfFlattened = dfSizeBlocks.Define("float_blocks",
+        [_DataBlockSize = DataBlockSize](const std::vector<float>& float_data, int nBlocks) -> std::vector<DataBlockFloat> {
             std::vector<DataBlockFloat> blocks;
             blocks.reserve(nBlocks);
             for (int i = 0; i < nBlocks; ++i) {
                 size_t offset = i * _DataBlockSize;
-                float channel = flat_data[offset];
+                float channel = float_data[offset];
                 // Only Save Waveforms from the block channels.
                 // Should add a more robust method here like isBlock(channel).
                 if(channel == 2000 || channel == 2001) {continue;}
-                float n_samples = flat_data[offset + 1];
+                float n_samples = float_data[offset + 1];
                 size_t num_to_copy = std::min<size_t>(n_samples, NumSamples);
-                const float* waveform_ptr = &flat_data[offset + 2];
+                const float* waveform_ptr = &float_data[offset + 2];
                 blocks.emplace_back(channel, n_samples, waveform_ptr, num_to_copy);
             }
             return blocks;
         },
-        {"waveform_block_data_float", "n_blocks"}
+        {"float_waveform_data", "n_channels"}
     );
 
     auto findPeaks = [_NumSamples = NumSamples](const DataBlockFloat &block) -> PeakContainer {
         PeakContainer result;
+        result.block = block.block_id;
         for (int it = 0; it < _NumSamples - 6; ++it) {
             if (block.data[it] < block.data[it+1] &&
                 block.data[it+1] < block.data[it+2] &&
@@ -111,7 +112,7 @@ void DataAnalysisManager::ProcessData() {
                 block.data[it+3] >= block.data[it+4] &&
                 block.data[it+4] > 0) {
                 if (result.nPeaks < PeakContainer::maxPeaks) {
-                    result.peaks[result.nPeaks].block = block.block_id;
+                    // Load PeakContainer::maxPeaks from config
                     result.peaks[result.nPeaks].amplitude = block.data[it+3];
                     result.peaks[result.nPeaks].time = static_cast<float>(it+3);
                     result.nPeaks++;
@@ -136,7 +137,7 @@ void DataAnalysisManager::ProcessData() {
             }
             return peaks;
         },
-        {"blocks_float"}
+        {"float_blocks"}
     );
 
     // Lambda to process a single ADC entry.
@@ -155,7 +156,7 @@ void DataAnalysisManager::ProcessData() {
 
     // Step 5: Calculate ADC parameters.
     // Here we encapsulate the ADC logic (like computing HMS time corrections,
-    auto dfAdc = dfPeaks.Define("adc_results",
+    auto dfAdc = dfPeaks.Define("adc_results_blocks",
         [_processAdcEntry = processAdcEntry,
          _tdcoffset = cfg.tdcOffsets,
          _adcSampleDivisions = adcSampleDivisions,
@@ -221,7 +222,7 @@ void DataAnalysisManager::ProcessData() {
             res.amplitude = 2.0;         // fallback amplitude
 
             for (int i = 0; i < pc.nPeaks; ++i) {
-                if (_isGoodPeak(pc.peaks[i].block, pc.peaks[i].time)) {
+                if (_isGoodPeak(pc.block, pc.peaks[i].time)) {
                     res.good = true;
                     res.time = pc.peaks[i].time;
                     res.amplitude = pc.peaks[i].amplitude;
@@ -235,7 +236,7 @@ void DataAnalysisManager::ProcessData() {
 
     // Step 6: Determine Fits for each peak based on time, amplitude and 'goodness'
     // Perform for each Peak within each DataBlockFloat, which is stored in block_peaks.
-    auto dfFitParams = dfAdc.Define("fit_results", computeFitParameters, {"block_peaks"});
+    auto dfFitParams = dfAdc.Define("fit_results_blocks", computeFitParameters, {"block_peaks"});
 
     // Step 7: Fit the actual data using Minuit2 and the relevant branches!
     // First I need to check the computeFitParameters and load config correctly.
@@ -249,9 +250,9 @@ void DataAnalysisManager::ProcessData() {
         "H.gtr.th",
         "H.gtr.ph",
         "H.gtr.dp",
-        "adc_results",
+        "adc_results_blocks",
         "block_peaks",
-        "fit_results"
+        "fit_results_blocks"
     };
 
     // Should likely flatten objects and store minimal arrays instead of vectors.  

--- a/src/DataAnalysisManager.cpp
+++ b/src/DataAnalysisManager.cpp
@@ -11,20 +11,19 @@
 #include <algorithm>  // for std::min
 
 // Constructor: store pointers to the other managers so we can use them in processing.
-DataAnalysisManager::DataAnalysisManager(int run,
-                                         TChain* chain,
-                                         const FileManager* fileMgr,
+DataAnalysisManager::DataAnalysisManager(const FileManager* fileMgr,
                                          const GlobalManager* globalMgr,
                                          const ReferenceManager* refMgr,
                                          const BranchManager* branchMgr,
                                          const ApplicationManager* appMgr)
-    : run(run), chain(chain), fileManager(fileMgr),
-      globalManager(globalMgr), referenceManager(refMgr), branchManager(branchMgr,
-      applicationManager(applicationMgr) )
+    : run(-1), chain(nullptr), fileManager(fileMgr), globalManager(globalMgr), 
+      referenceManager(refMgr), branchManager(branchMgr),
+      applicationManager(appMgr)
 {
 }
 
-void DataAnalysisManager::SetupParameters() const {
+void DataAnalysisManager::SetupParameters() {
+    chain = fileManager->GetInputChain();
     if(applicationManager) {
         cfg.nCores = applicationManager->GetNProcs();
     }
@@ -41,10 +40,11 @@ void DataAnalysisManager::SetupParameters() const {
 }
 
 void DataAnalysisManager::ProcessData() {
+    this->SetupParameters();
     // Check WaveformAnalysis Version
 
     // Enable multi-threading using the number of cores from configuration.
-    ROOT::EnableImplicitMT(nCores);
+    ROOT::EnableImplicitMT(cfg.nCores);
 
     // Create the initial RDataFrame from the TChain.
     ROOT::RDataFrame df(*chain);
@@ -137,7 +137,7 @@ void DataAnalysisManager::ProcessData() {
     );
 
     // Lambda to process a single ADC entry.
-    auto processAdcEntry = [_timemean2 = timemean2](AdcResult& res,
+    auto processAdcEntry = [_timemean2 = cfg.timemean2](AdcResult& res,
         float pulseAmp, float pulseTime, float pulseInt,
         float pulsePed, int Npulse) {
         // If it's the first pulse or the new pulse is closer to the reference time, update the result.
@@ -154,9 +154,9 @@ void DataAnalysisManager::ProcessData() {
     // Here we encapsulate the ADC logic (like computing HMS time corrections,
     auto dfAdc = dfPeaks.Define("adc_results",
         [_processAdcEntry = processAdcEntry,
-         _tdcoffset = tdcoffset,
+         _tdcoffset = cfg.tdcOffsets,
          _adcSampleDivisions = adcSampleDivisions,
-         timemean2 = timemean2,](int NadcCounters,
+         timemean2 = cfg.timemean2](int NadcCounters,
                            const ROOT::RVec<double>& adcCounters,
                            const ROOT::RVec<double>& adcSampPulseTime,
                            const ROOT::RVec<double>& adcSampPulseTimeRaw,
@@ -169,10 +169,20 @@ void DataAnalysisManager::ProcessData() {
             eventData.adcResults.resize(NadcCounters);
 
             // Skip if adcCounter is for Scintillators
-    
+            int counter = adcCounters[0];
+            auto it = _tdcoffset.find(counter);
+            double offset = 0.0;
+            
+            if (it != _tdcoffset.end()) {
+                offset = it->second;
+            } else {
+                std::cerr << "Warning: Missing tdcOffset for adcCounter " << counter << " — using 0.0\n";
+            }
+            
             eventData.HMS_corr_time = adcSampPulseTime[0] -
                                       (adcSampPulseTimeRaw[0] / _adcSampleDivisions) -
-                                      _tdcoffset[adcCounters[0]];
+                                      offset;
+            
                                       // The _tdcoffset for adcCounters[0],
                                       // IDK what that is.
                                       // Maybe the block that fired off the event?
@@ -199,15 +209,21 @@ void DataAnalysisManager::ProcessData() {
     );
 
     // Lambda for checking peak quality using the tolerance from GlobalManager.
-    auto isGoodPeak = [_timeref = timeref, 
-                       _peakTolerance = peakTolerance,
-                       _timerefacc = timerefacc](int block_number, double peakTime) -> bool {
-        return std::fabs(peakTime - _timeref[block_number] - _timerefacc) < _peakTolerance;
+    auto isGoodPeak = [_timeref = cfg.timeRefs, 
+                       _peakTolerance = cfg.peakTolerance,
+                       _timerefacc = cfg.timerefacc](int block_number, double peakTime) -> bool {
+        auto it = _timeref.find(block_number);
+        if (it != _timeref.end()) {
+            return std::fabs(peakTime - it->second - _timerefacc) < _peakTolerance;
+        } else {
+            std::cerr << "Warning: Missing timeref for block " << block_number << " — using 0.0\n";
+            return std::fabs(peakTime - 0.0 - _timerefacc) < _peakTolerance;  // fallback
+        }
     };
 
     // Lambda to compute fit parameters for each block.
     auto computeFitParameters = [_isGoodPeak = isGoodPeak,
-                                 timerefacc = timerefacc]
+                                 timerefacc = cfg.timerefacc]
             (const std::vector<PeakContainer>& blockPeaks) -> std::vector<FitResults> {
         std::vector<FitResults> results;
         results.reserve(blockPeaks.size());

--- a/src/GlobalManager.cpp
+++ b/src/GlobalManager.cpp
@@ -9,6 +9,10 @@ int GlobalManager::GetNblocks() const {
     return config.nblocks;
 }
 
+double GlobalManager::GetTimeRefAcc() const {
+    return config.timerefacc;
+}
+
 int GlobalManager::GetNtime() const {
     return config.ntime;
 }

--- a/src/ReferenceManager.cpp
+++ b/src/ReferenceManager.cpp
@@ -121,6 +121,9 @@ bool ReferenceManager::LoadReferenceWaveforms() {
                 continue;
             }
 
+            timeRefs[block] = timeRef;
+            tdcOffsets[block] = tdcOffset;
+
             auto interpolator = std::make_unique<ROOT::Math::Interpolator>(xbins.size(), ROOT::Math::Interpolation::kCSPLINE);
             interpolator->SetData(xbins.size(), xbins.data(), y.data());
             interpolators[block] = std::move(interpolator);
@@ -150,6 +153,22 @@ bool ReferenceManager::LoadReferenceWaveforms() {
 const ROOT::Math::Interpolator* ReferenceManager::GetInterpolator(int block) const {
     auto it = interpolators.find(block);
     return (it != interpolators.end()) ? it->second.get() : nullptr;
+}
+
+std::map<int,double> GetTimeRefs() const {
+    return timeRefs;
+}
+
+std::map<int,double> GettdcOffsets() const {
+    return tdcOffsets;
+}
+
+double GetTimeMean() const {
+    return refConfig.timemean;
+}
+
+double GetTimeMean2() const {
+    return refConfig.timemean2;
 }
 
 TF1* ReferenceManager::GetFitter(int block) const {

--- a/src/ReferenceManager.cpp
+++ b/src/ReferenceManager.cpp
@@ -155,19 +155,19 @@ const ROOT::Math::Interpolator* ReferenceManager::GetInterpolator(int block) con
     return (it != interpolators.end()) ? it->second.get() : nullptr;
 }
 
-std::map<int,double> GetTimeRefs() const {
+std::map<int,double> ReferenceManager::GetTimeRefs() const {
     return timeRefs;
 }
 
-std::map<int,double> GettdcOffsets() const {
+std::map<int,double> ReferenceManager::GettdcOffsets() const {
     return tdcOffsets;
 }
 
-double GetTimeMean() const {
+double ReferenceManager::GetTimeMean() const {
     return refConfig.timemean;
 }
 
-double GetTimeMean2() const {
+double ReferenceManager::GetTimeMean2() const {
     return refConfig.timemean2;
 }
 


### PR DESCRIPTION
Add several get methods from managers.
Add ApplyConfig() to all managers.
Remove dependency on run in ConfigManager.  ConfigManager now only converts the config.json spec into structs to be loaded by their respective Manager.  
RunOverrides are now applied in GlobalManager.  Restructuring of the config.json would be ideal so the variables could directly be determined by run number instead of casting key:value pair through the ConfigManager -> GlobalManager interface (struct).  
